### PR TITLE
Update mlcm.py

### DIFF
--- a/mlcm/mlcm.py
+++ b/mlcm/mlcm.py
@@ -77,8 +77,8 @@ def cm(label_true,label_pred,print_note=True):
                     if label_true[i][j] == 1: 
                         conf_mat[j][num_classes] += 1  # NPL               
             else: 
-                true_checked = np.zeros((num_classes,1), dtype=np.int) 
-                pred_checked = np.zeros((num_classes,1), dtype=np.int) 
+                true_checked = np.zeros((num_classes,1), dtype=int) 
+                pred_checked = np.zeros((num_classes,1), dtype=int) 
                 # Check for correct prediction
                 for j in range(num_classes): 
                     if label_true[i][j] == 1: 


### PR DESCRIPTION
`module 'numpy' has no attribute 'int'.
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information. The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations`